### PR TITLE
Update README with Dependency Installation Instructions and Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Compiler files
+cache/
+out/

--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ The project was developed using Solidity, OpenZeppelin libraries, and is designe
 git clone <repository-url>
 cd <repository-folder>
 
+forge install OpenZeppelin/openzeppelin-contracts
+forge install foundry-rs/forge-std
+
 forge compile
 forge test
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ The project was developed using Solidity, OpenZeppelin libraries, and is designe
 git clone <repository-url>
 cd <repository-folder>
 
-forge install OpenZeppelin/openzeppelin-contracts
+forge install OpenZeppelin/openzeppelin-contracts@v5.1.0
 forge install foundry-rs/forge-std
 
 forge compile


### PR DESCRIPTION
Here, I updated the README with installation instructions for `OpenZeppelin/openzeppelin-contracts` and `foundry-rs/forge-std`.

Additionally, a `.gitignore` file is created to exclude the directories `cache/` and `out/`, as they mess with the version control.